### PR TITLE
move sdm6xx devices to kernel 4.14

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -16,7 +16,7 @@
 PLATFORM_COMMON_PATH := device/sony/ganges
 
 SOMC_PLATFORM := ganges
-SOMC_KERNEL_VERSION := 4.9
+SOMC_KERNEL_VERSION := 4.14
 KERNEL_PATH := kernel/sony/msm-$(SOMC_KERNEL_VERSION)
 
 $(call inherit-product, device/sony/common/common.mk)


### PR DESCRIPTION
Move devices to kernel 4.14 and new HALs

Signed-off-by: Alin Jerpelea <alin.jerpelea@sony.com>